### PR TITLE
Feature/polymorphic #10

### DIFF
--- a/packages/poly/README.md
+++ b/packages/poly/README.md
@@ -1,8 +1,45 @@
 # `over-ui/poly`
 
+`as` prop을 사용해, 컴포넌트의 태그를 다형적으로 이용할 수 있도록 하는 `type` 입니다.  
+이 `type`을 사용함으로써, 해당 태그에 맞는 `attribute`만을 받을 수 있으며 해당태그에 맞지 않는다면 타입스크립트에서 오류가 발생합니다.
+
 ## Usage
 
-```
-`package.json`에 `private` 옵션을 `false` 로 바꿔 주셔야 합니다.
-이 템플릿은, 배포용이 아닌 내부에서 사용하기 위에 적용된 파일입니다.
+```tsx
+import * as React from "react";
+import * as Poly from "@over-ui/poly";
+
+const DEFAULT_DEMO_TAG = "div";
+
+export type DemoProps = {
+ */ write DemoComponent Props */
+  children?: React.ReactNode;
+  */ render Props가 사용되는 컴포넌트가 존재해, children을 기본 type지정에서 제거했습니다. */
+};
+
+export const Demo: Poly.Component<typeof DEFAULT_DEMO_TAG, DemoProps> =
+  React.forwardRef(
+    <T extends React.ElementType = typeof DEFAULT_DEMO_TAG>(
+      props: Poly.Props<T, DemoProps>,
+      forwardedRef: Poly.Ref<T>,
+    ) => {
+      const {
+        as,
+        ...restProps
+      } = props;
+
+      const Component = as || DEFAULT_TOGGLE;
+
+      return (
+        <Component
+          {...restProps}
+        >
+          {children}
+        </Component>
+      );
+    },
+  );
+
+Demo.displayName = "Demo";
+
 ```

--- a/packages/poly/README.md
+++ b/packages/poly/README.md
@@ -1,0 +1,8 @@
+# `over-ui/poly`
+
+## Usage
+
+```
+`package.json`에 `private` 옵션을 `false` 로 바꿔 주셔야 합니다.
+이 템플릿은, 배포용이 아닌 내부에서 사용하기 위에 적용된 파일입니다.
+```

--- a/packages/poly/package.json
+++ b/packages/poly/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@over-ui/poly",
+  "version": "1.0.0",
+  "license": "MIT",
+  "contributors": [
+    "otterp012 <otterp012@gmail.com>",
+    "lv0314 <luzverde0314@gmail.com>"
+  ],
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:typings && rollup -c ../../rollup.config.mjs",
+    "watch": "rollup -c ../../rollup.config.mjs -w",
+    "build:typings": "tsc -p ./tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/over-ui/unstyled/tree/main#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/over-ui/unstyled.git"
+  },
+  "bugs": {
+    "url": "https://github.com/over-ui/unstyled/issues"
+  }
+}

--- a/packages/poly/src/index.ts
+++ b/packages/poly/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./poly";

--- a/packages/poly/src/poly.ts
+++ b/packages/poly/src/poly.ts
@@ -14,3 +14,14 @@ export type Ref<C extends React.ElementType> =
 export type PropsWithRef<C extends React.ElementType, P = {}> = Props<C, P> & {
   ref?: Ref<C>;
 };
+
+type DisplayName = {
+  displayName?: string;
+};
+
+export type Component<C extends React.ElementType, _Props> = (<
+  T extends React.ElementType = C,
+>(
+  props: PropsWithRef<T, _Props>,
+) => React.ReactElement | null) &
+  DisplayName;

--- a/packages/poly/src/poly.ts
+++ b/packages/poly/src/poly.ts
@@ -1,0 +1,16 @@
+type AsProp<C extends React.ElementType> = {
+  as?: C;
+};
+
+type PropsToOmit<C extends React.ElementType, P> = keyof (AsProp<C> & P);
+
+export type Props<C extends React.ElementType, Props = {}> = Props &
+  AsProp<C> &
+  Omit<React.ComponentPropsWithoutRef<C>, PropsToOmit<C, Props>>;
+
+export type Ref<C extends React.ElementType> =
+  React.ComponentPropsWithRef<C>["ref"];
+
+export type PropsWithRef<C extends React.ElementType, P = {}> = Props<C, P> & {
+  ref?: Ref<C>;
+};

--- a/packages/poly/tsconfig.json
+++ b/packages/poly/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/index.ts"],
+  "compilerOptions": {
+    "declarationDir": "./dist"
+  }
+}


### PR DESCRIPTION
Closes #10 

# 구현 내용
- `polymorphic types` 구현 
- 위 타입을 간소화하여 사용할 수 있는 `Component` 타입 구현
- README.MD 작성

## 동작 예시
```tsx
import * as React from "react";
import * as Poly from "@over-ui/poly";
const DEFAULT_DEMO_TAG = "div";
export type DemoProps = {
 */ write DemoComponent Props */
  children?: React.ReactNode;
  */ render Props가 사용되는 컴포넌트가 존재해, children을 기본 type지정에서 제거했습니다. */
};
export const Demo: Poly.Component<typeof DEFAULT_DEMO_TAG, DemoProps> =
  React.forwardRef(
    <T extends React.ElementType = typeof DEFAULT_DEMO_TAG>(
      props: Poly.Props<T, DemoProps>,
      forwardedRef: Poly.Ref<T>,
    ) => {
      const {
        as,
        ...restProps
      } = props;
      const Component = as || DEFAULT_TOGGLE;
      return (
        <Component
          {...restProps}
        >
          {children}
        </Component>
      );
    },
  );

Demo.displayName = "Demo";
```

## 기타사항
- #14 디스커션 진행에 따라, 해당 패키지 구현 수정 필요
