### PR TITLE
Feature/portal #25

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,8 @@
   },
   "rules": {
     "no-console": "error",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "import/no-unresolved": "off"
   },
   "overrides": [
     {

--- a/packages/portal/README.md
+++ b/packages/portal/README.md
@@ -1,10 +1,53 @@
-# `over-test`
+# `over-ui/portal`
 
-> TODO: description
+`portal` 패키지는, 컴포넌트에서 모달 기능을 사용할 때 필요한 포탈을 생성하는 컴포넌트입니다.
+임의로 `container`를 지정해서 그 곳에 포탈을 열 수 있고, 지정되지 않았다면 기본값으로 `body`에 포탈이 생성됩니다
 
 ## Usage
 
-```
-`package.json`에 `private` 옵션을 `false` 로 바꿔 주셔야 합니다.
-이 템플릿은, 배포용이 아닌 내부에서 사용하기 위에 적용된 파일입니다.
+### portal
+
+```tsx
+import * as React from 'react';
+import { Poly } from '@over-ui/core';
+import { Portal as PortalPrimitive } from '@over-ui/portal';
+
+type DemoPortalProps = {
+  container?: HTMLElement | null;
+  children?: React.ReactNode;
+};
+
+const DemoPortal = (props: DemoPortalProps) => {
+  const { children, container } = props;
+
+  /* context나 state가 있을 경우 모달이 열리는 조건으로 활용할 수 있습니다 */
+  return <PortalPrimitive container={container}>{children}</PortalPrimitive>;
+};
+
+type DemoPortalContentProps = {
+  children?: React.ReactNode;
+};
+
+const DEFAULT_DEMO_TAG = 'div';
+
+const DemoPortalContent: Poly.Component<typeof DEFAULT_DEMO_TAG, DemoPortalContentProps> =
+  React.forwardRef(
+    <T extends React.ElementType = typeof DEFAULT_DEMO_TAG>(
+      props: Poly.Props<T, DemoPortalContentProps>,
+      forwardedRef: Poly.Ref<T>
+    ) => {
+      const { as, children, ...restProps } = props;
+
+      const Tag = as || DEFAULT_DEMO_TAG;
+
+      return (
+        /* container props를 활용하여 container를 직접 지정해 줄 수 있습니다 */
+        <DemoPortal>
+          <Tag {...restProps} ref={forwardedRef}>
+            {children}
+          </Tag>
+        </DemoPortal>
+      );
+    }
+  );
 ```

--- a/packages/portal/README.md
+++ b/packages/portal/README.md
@@ -1,0 +1,10 @@
+# `over-test`
+
+> TODO: description
+
+## Usage
+
+```
+`package.json`에 `private` 옵션을 `false` 로 바꿔 주셔야 합니다.
+이 템플릿은, 배포용이 아닌 내부에서 사용하기 위에 적용된 파일입니다.
+```

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@over-ui/portal",
+  "version": "1.0.0",
+  "private": false,
+  "license": "MIT",
+  "contributors": [
+    "otterp012 <otterp012@gmail.com>",
+    "lv0314 <luzverde0314@gmail.com>"
+  ],
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:typings && rollup -c ../../rollup.config.mjs",
+    "watch": "rollup -c ../../rollup.config.mjs -w",
+    "build:typings": "tsc -p ./tsconfig.json",
+    "clean": "rm -rf dist",
+    "lint": "eslint ./src"
+  },
+  "dependencies": {
+    "@over-ui/core": "*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/over-ui/unstyled/tree/main#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/over-ui/unstyled.git"
+  },
+  "bugs": {
+    "url": "https://github.com/over-ui/unstyled/issues"
+  }
+}

--- a/packages/portal/src/Portal.tsx
+++ b/packages/portal/src/Portal.tsx
@@ -1,23 +1,31 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
+import { Poly } from '@over-ui/core';
 
 /* -------------------------------------------------------------------------------------------------
  * Portal
  * -----------------------------------------------------------------------------------------------*/
-const PORTAL_NAME = 'Portal';
-
-type PortalElement = HTMLDivElement;
 type PortalProps = {
   container?: HTMLElement | null;
   children?: React.ReactNode;
 };
 
-export const Portal = React.forwardRef<PortalElement, PortalProps>((props, forwardedRef) => {
-  const { container = globalThis?.document?.body, ...portalProps } = props;
+const PORTAL_TAG = 'div';
 
-  return container
-    ? ReactDOM.createPortal(<div {...portalProps} ref={forwardedRef} />, container)
-    : null;
-});
+const Portal: Poly.Component<typeof PORTAL_TAG, PortalProps> = React.forwardRef(
+  <T extends React.ElementType = typeof PORTAL_TAG>(
+    props: Poly.Props<T, PortalProps>,
+    forwardedRef: Poly.Ref<T>
+  ) => {
+    const { as, container = globalThis?.document?.body, ...portalProps } = props;
+    const Component = as || PORTAL_TAG;
 
-Portal.displayName = PORTAL_NAME;
+    return container
+      ? ReactDOM.createPortal(<Component {...portalProps} ref={forwardedRef} />, container)
+      : null;
+  }
+);
+
+Portal.displayName = 'PORTAL';
+
+export { Portal };

--- a/packages/portal/src/Portal.tsx
+++ b/packages/portal/src/Portal.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+
+/* -------------------------------------------------------------------------------------------------
+ * Portal
+ * -----------------------------------------------------------------------------------------------*/
+const PORTAL_NAME = 'Portal';
+
+type PortalElement = HTMLDivElement;
+type PortalProps = {
+  container?: HTMLElement | null;
+  children?: React.ReactNode;
+};
+
+export const Portal = React.forwardRef<PortalElement, PortalProps>((props, forwardedRef) => {
+  const { container = globalThis?.document?.body, ...portalProps } = props;
+
+  return container
+    ? ReactDOM.createPortal(<div {...portalProps} ref={forwardedRef} />, container)
+    : null;
+});
+
+Portal.displayName = PORTAL_NAME;

--- a/packages/portal/src/Portal.tsx
+++ b/packages/portal/src/Portal.tsx
@@ -18,10 +18,10 @@ const Portal: Poly.Component<typeof PORTAL_TAG, PortalProps> = React.forwardRef(
     forwardedRef: Poly.Ref<T>
   ) => {
     const { as, container = globalThis?.document?.body, ...portalProps } = props;
-    const Component = as || PORTAL_TAG;
+    const Tag = as || PORTAL_TAG;
 
     return container
-      ? ReactDOM.createPortal(<Component {...portalProps} ref={forwardedRef} />, container)
+      ? ReactDOM.createPortal(<Tag {...portalProps} ref={forwardedRef} />, container)
       : null;
   }
 );

--- a/packages/portal/src/index.ts
+++ b/packages/portal/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Portal';

--- a/packages/portal/tsconfig.json
+++ b/packages/portal/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/index.ts"],
+  "compilerOptions": {
+    "declarationDir": "./dist"
+  }
+}


### PR DESCRIPTION
closes #25 

## 구현 내용
`portal` 패키지는, 컴포넌트에서 모달 기능을 사용할 때 필요한 포탈을 생성하는 컴포넌트입니다.
임의로 `container`를 지정해서 그 곳에 포탈을 열 수 있고, 지정되지 않았다면 기본값으로 `body`에 포탈이 생성됩니다

### 동작 예시
```tsx
import * as React from 'react';
import { Poly } from '@over-ui/core';
import { Portal as PortalPrimitive } from '@over-ui/portal';

type DemoPortalProps = {
  container?: HTMLElement | null;
  children?: React.ReactNode;
};

const DemoPortal = (props: DemoPortalProps) => {
  const { children, container } = props;

  /* context나 state가 있을 경우 모달이 열리는 조건으로 활용할 수 있습니다 */
  return <PortalPrimitive container={container}>{children}</PortalPrimitive>;
};

type DemoPortalContentProps = {
  children?: React.ReactNode;
};

const DEFAULT_DEMO_TAG = 'div';

const DemoPortalContent: Poly.Component<typeof DEFAULT_DEMO_TAG, DemoPortalContentProps> =
  React.forwardRef(
    <T extends React.ElementType = typeof DEFAULT_DEMO_TAG>(
      props: Poly.Props<T, DemoPortalContentProps>,
      forwardedRef: Poly.Ref<T>
    ) => {
      const { as, children, ...restProps } = props;

      const Tag = as || DEFAULT_DEMO_TAG;

      return (
        /* container props를 활용하여 container를 직접 지정해 줄 수 있습니다 */
        <DemoPortal>
          <Tag {...restProps} ref={forwardedRef}>
            {children}
          </Tag>
        </DemoPortal>
      );
    }
  );
```