### PR TITLE
Feature/focusTrapLayer #34

### DIFF
--- a/packages/focusTrapLayer/README.md
+++ b/packages/focusTrapLayer/README.md
@@ -1,10 +1,35 @@
-# `over-test`
+# `over-ui/focusTrapLayer`
 
-> TODO: description
+`focusTrapLayer` 패키지는, `over-ui`내부에서만 사용되는 패키지입니다.
+
+over-ui 상의 Dialog 등 모달을 사용하는 컴포넌트에서는, 컴포넌트 `밖으로 포커스가 나가면 모달이 닫히게` 됩니다. 이러한 의도치 않은 동작을 막기 위해 FocusTrapLayer 컴포넌트를 개발하게 되었습니다. `FocusTrapLayer`는 container 안에서 `focusable하고 조건에 맞는 엘리먼트들`을 모아 해당 엘리먼트들만 포커스가 되도록 `포커스를 가둠`으로써 포커스가 밖으로 튀어 나가 모달을 닫는 동작을 방지합니다.
 
 ## Usage
 
+```tsx
+import * as React from 'react';
+import { FocusTrapLayer } from '@over-ui/focusTrapLayer';
+
+const DemoPage = () => {
+  return (
+    <>
+      <FocusTrapLayer loop>
+        <h2 tabIndex={0}>title</div>
+        <div>description</div>
+        <input id="id"/>
+        <input id="password"/>
+        <input id="nickname"tabIndex={-1}/>
+        <button>cancel</button>
+        <button>submit</button>
+      </FocusTrapLayer>
+    </>
+  );
+};
+
+export default DemoPage;
 ```
-`package.json`에 `private` 옵션을 `false` 로 바꿔 주셔야 합니다.
-이 템플릿은, 배포용이 아닌 내부에서 사용하기 위에 적용된 파일입니다.
-```
+
+## Result
+
+FocusTrapLayer 내부에 있는 포커스가 가능한 요소들, 위와 같은 영우에는 `h2, input(id), input(password), button(cancel), button(submit)` 총 5개의 요소가 포커스가 가능하기때문에 이 5개의 요소 안에 포커스를 가두게되고 밖으로 포커스가 나가지 않게 된다.  
+또한 loop 옵션을 줬기 때문에 마지막 submit가 포커스 된 상태로 tab키를 누르면 첫 번째인 h2로 포커스가 이동하고, h2에 포커스가 된 상태로 shift키와 tab키를 같이 누르면 마지막 요소인 submit으로 포커스가 이동하게 된다.

--- a/packages/focusTrapLayer/README.md
+++ b/packages/focusTrapLayer/README.md
@@ -1,0 +1,10 @@
+# `over-test`
+
+> TODO: description
+
+## Usage
+
+```
+`package.json`에 `private` 옵션을 `false` 로 바꿔 주셔야 합니다.
+이 템플릿은, 배포용이 아닌 내부에서 사용하기 위에 적용된 파일입니다.
+```

--- a/packages/focusTrapLayer/package.json
+++ b/packages/focusTrapLayer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@over-ui/focusTrapLayer",
+  "name": "@over-ui/focus-trap-layer",
   "version": "1.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/focusTrapLayer/package.json
+++ b/packages/focusTrapLayer/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@over-ui/focusTrapLayer",
+  "version": "1.0.0",
+  "private": false,
+  "license": "MIT",
+  "contributors": [
+    "otterp012 <otterp012@gmail.com>",
+    "lv0314 <luzverde0314@gmail.com>"
+  ],
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:typings && rollup -c ../../rollup.config.mjs",
+    "watch": "rollup -c ../../rollup.config.mjs -w",
+    "build:typings": "tsc -p ./tsconfig.json",
+    "clean": "rm -rf dist",
+    "lint": "eslint ./src"
+  },
+  "dependencies": {
+    "@over-ui/core": "*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/over-ui/unstyled/tree/main#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/over-ui/unstyled.git"
+  },
+  "bugs": {
+    "url": "https://github.com/over-ui/unstyled/issues"
+  }
+}

--- a/packages/focusTrapLayer/src/FocusTrapLayer.tsx
+++ b/packages/focusTrapLayer/src/FocusTrapLayer.tsx
@@ -78,3 +78,44 @@ function focus(element?: FocusableTarget | null, { select = false } = {}) {
     }
   }
 }
+
+/* -------------------------------------------------------------------------------------------------
+ * FocusTrapLayerStack
+ * -----------------------------------------------------------------------------------------------*/
+type focusScope = { paused: boolean; pause(): void; resume(): void };
+
+const focusTrapLayerStack = createFocusTrapLayerStack();
+
+function createFocusTrapLayerStack() {
+  let stack: focusScope[] = [];
+
+  return {
+    add(layer: focusScope) {
+      // 스택이기 때문에 가장 나중에 쌓인 layer가 활성화되어있음
+      const activeFocusScope = stack.at(-1);
+      // 인자로 들어온 스코프와 스택 맨 위의 스코프가 다르면, 활성화되어었는 스코프를 중지시키고
+      // 인자로 들어온 스코프를 스코프 스택 맨 위에 넣음
+      if (layer !== activeFocusScope) {
+        activeFocusScope?.pause();
+      }
+
+      stack = arrayWithoutItem(stack, layer);
+      stack.push(layer);
+    },
+
+    remove(layer: focusScope) {
+      stack = arrayWithoutItem(stack, layer);
+      stack.at(-1)?.resume();
+    },
+  };
+}
+
+function arrayWithoutItem<T>(array: T[], item: T) {
+  let copiedArr = [...array];
+  const index = copiedArr.indexOf(item);
+  if (index !== -1) {
+    copiedArr = copiedArr.filter((node) => node !== item);
+  }
+
+  return copiedArr;
+}

--- a/packages/focusTrapLayer/src/FocusTrapLayer.tsx
+++ b/packages/focusTrapLayer/src/FocusTrapLayer.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { Poly } from '@over-ui/core';
+
+/* -------------------------------------------------------------------------------------------------
+ * Utils
+ * -----------------------------------------------------------------------------------------------*/
+//포커스 가능한 엘리먼트들을 찾는 메서드
+function getFocusableElements(container: HTMLElement) {
+  const nodes: HTMLElement[] = [];
+  // TreeWalker를 사용해서 트리를 탐색
+  // createTreeWalker(root, whatToShow, filter), return TreeWalker object
+  // https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, {
+    acceptNode: (node: any) => {
+      //input 태그이지만 안보이는 경우 스킵
+      const isHiddenInput = node.tagName === 'INPUT' && node.type === 'hidden';
+      if (node.disabled || node.hidden || isHiddenInput) return NodeFilter.FILTER_SKIP;
+
+      return node.tabIndex >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+    },
+  });
+  // 첫 번째는 container TreeWalker object를 반환하므로 넘어 감
+  // returns the first child of root, as it is the next node in document order, and so on
+  while (walker.nextNode()) nodes.push(walker.currentNode as HTMLElement);
+
+  return nodes;
+}
+
+function getFocusableEdges(container: HTMLElement) {
+  const elements = getFocusableElements(container);
+
+  const first = getFirstVisibleElement(elements, container);
+  const last = getFirstVisibleElement(elements.reverse(), container);
+
+  return [first, last] as const;
+}
+
+function focusFirst(eleements: HTMLElement[], container: HTMLElement, { select = false } = {}) {
+  focus(getFirstVisibleElement(eleements, container), { select });
+}
+
+function isHidden(node: HTMLElement, upTo: HTMLElement) {
+  //인자로 받은 요소의 모든 CSS 속성값을 담은 객체를 반환
+  //https://developer.mozilla.org/ko/docs/Web/API/Window/getComputedStyle
+  if (getComputedStyle(node).visibility === 'hidden') return true;
+
+  while (node) {
+    // 해당 노드는 visible이지만, container level에서 invisible일 수 있기 때문에
+    // container level까지 타고 올라가면서 검사
+    if (upTo !== undefined && node === upTo) return false;
+    if (getComputedStyle(node).display === 'none') return true;
+    node = node.parentElement as HTMLElement;
+  }
+
+  return false;
+}
+
+function getFirstVisibleElement(elements: HTMLElement[], container: HTMLElement) {
+  for (const element of elements) {
+    if (!isHidden(element, container)) return element;
+  }
+}
+
+type FocusableTarget = HTMLElement | { focus(): void };
+
+// selectable이면 focus해줄 때 select도 같이 해주기 위해서
+function isSelectableInput(element: any): element is FocusableTarget & { select: () => void } {
+  return element instanceof HTMLInputElement && 'select' in element;
+}
+
+function focus(element?: FocusableTarget | null, { select = false } = {}) {
+  if (element && element.focus) {
+    const previouslyFocusedElement = document.activeElement;
+    element.focus();
+
+    if (element !== previouslyFocusedElement && isSelectableInput(element) && select) {
+      element.select();
+    }
+  }
+}

--- a/packages/focusTrapLayer/src/index.ts
+++ b/packages/focusTrapLayer/src/index.ts
@@ -1,0 +1,1 @@
+export * from './FocusTrapLayer';

--- a/packages/focusTrapLayer/tsconfig.json
+++ b/packages/focusTrapLayer/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/index.ts"],
+  "compilerOptions": {
+    "declarationDir": "./dist"
+  }
+}


### PR DESCRIPTION
closes #34

## Description
`focusTrapLayer` 패키지는, `over-ui`내부에서만 사용되는 패키지입니다.

over-ui 상의 Dialog 등 모달을 사용하는 컴포넌트에서는, 컴포넌트 `밖으로 포커스가 나가면 모달이 닫히게` 됩니다. 이러한 의도치 않은 동작을 막기 위해 FocusTrapLayer 컴포넌트를 개발하게 되었습니다. `FocusTrapLayer`는 container 안에서 `focusable하고 조건에 맞는 엘리먼트들`을 모아 해당 엘리먼트들만 포커스가 되도록 `포커스를 가둠`으로써 포커스가 밖으로 튀어 나가 모달을 닫는 동작을 방지합니다.

## Usage

```tsx
import * as React from 'react';
import { FocusTrapLayer } from '@over-ui/focusTrapLayer';

const DemoPage = () => {
  return (
    <>
      <FocusTrapLayer loop>
        <h2 tabIndex={0}>title</div>
        <div>description</div>
        <input id="id"/>
        <input id="password"/>
        <input id="nickname"tabIndex={-1}/>
        <button>cancel</button>
        <button>submit</button>
      </FocusTrapLayer>
    </>
  );
};

export default DemoPage;
```

## Result

FocusTrapLayer 내부에 있는 포커스가 가능한 요소들, 위와 같은 영우에는 `h2, input(id), input(password), button(cancel), button(submit)` 총 5개의 요소가 포커스가 가능하기때문에 이 5개의 요소 안에 포커스를 가두게되고 밖으로 포커스가 나가지 않게 됩니다.  
또한 `loop` 옵션을 줬기 때문에 마지막 submit가 포커스 된 상태로 tab키를 누르면 첫 번째인 h2로 포커스가 이동하고, h2에 포커스가 된 상태로 shift키와 tab키를 같이 누르면 마지막 요소인 submit으로 포커스가 이동하게 됩니다.