### PR TITLE
Feautre/use-controlled #41

### DIFF
--- a/packages/mergeRefs/README.md
+++ b/packages/mergeRefs/README.md
@@ -5,17 +5,16 @@
 
 ## Usage
 
-```
+```jsx
 const Toggle = React.forwardRef((props, ref) => {
   const innerRef = React.useRef(null);
   return <button ref={mergeRefs([innerRef, ref])}>토글</button>;
 });
-
 ```
 
 위와 같은 상황에서 주로 사용합니다. 부모로부터 내려받은 `ref`와 내부에 있는 `innerRef`를 병합할 수 있습니다.
 
-```
+```jsx
 const Toggle = React.forwardRef((props, ref) => {
   return <button ref={mergeRefs([(node) => node?.focus(), ref])}>토글</button>;
 });

--- a/packages/mergeRefs/README.md
+++ b/packages/mergeRefs/README.md
@@ -1,0 +1,24 @@
+# `over-ui/mergeRefs`
+
+`mergeRefs` 패키지는, `over-ui` 에서 `ref` 를 병합하기 위한 유틸함수입니다.
+내부에서만 사용하는 패키지입니다.
+
+## Usage
+
+```
+const Toggle = React.forwardRef((props, ref) => {
+  const innerRef = React.useRef(null);
+  return <button ref={mergeRefs([innerRef, ref])}>토글</button>;
+});
+
+```
+
+위와 같은 상황에서 주로 사용합니다. 부모로부터 내려받은 `ref`와 내부에 있는 `innerRef`를 병합할 수 있습니다.
+
+```
+const Toggle = React.forwardRef((props, ref) => {
+  return <button ref={mergeRefs([(node) => node?.focus(), ref])}>토글</button>;
+});
+```
+
+`ref Callback`의 사용또한 가능합니다.

--- a/packages/mergeRefs/package.json
+++ b/packages/mergeRefs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@over-ui/mergeRefs",
+  "name": "@over-ui/merge-refs",
   "version": "1.0.0",
   "license": "MIT",
   "contributors": [

--- a/packages/mergeRefs/package.json
+++ b/packages/mergeRefs/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@over-ui/mergeRefs",
+  "version": "1.0.0",
+  "license": "MIT",
+  "contributors": [
+    "otterp012 <otterp012@gmail.com>",
+    "lv0314 <luzverde0314@gmail.com>"
+  ],
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:typings && rollup -c ../../rollup.config.mjs",
+    "watch": "rollup -c ../../rollup.config.mjs -w",
+    "build:typings": "tsc -p ./tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/over-ui/unstyled/tree/main#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/over-ui/unstyled.git"
+  },
+  "bugs": {
+    "url": "https://github.com/over-ui/unstyled/issues"
+  }
+}

--- a/packages/mergeRefs/src/index.ts
+++ b/packages/mergeRefs/src/index.ts
@@ -1,0 +1,1 @@
+export * from './mergeRefs';

--- a/packages/mergeRefs/src/mergeRefs.ts
+++ b/packages/mergeRefs/src/mergeRefs.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export function mergeRefs<T>(
+  refs: Array<React.MutableRefObject<T> | React.LegacyRef<T>>
+): React.RefCallback<T> {
+  return (value) => {
+    for (const ref of refs) {
+      if (!ref) continue;
+      if (typeof ref === 'function') {
+        ref(value);
+      } else {
+        (ref as React.MutableRefObject<T | null>).current = value;
+      }
+    }
+  };
+}

--- a/packages/mergeRefs/tsconfig.json
+++ b/packages/mergeRefs/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/index.ts"],
+  "compilerOptions": {
+    "declarationDir": "./dist"
+  }
+}

--- a/packages/useControlled/README.md
+++ b/packages/useControlled/README.md
@@ -5,7 +5,7 @@
 
 ## Usage
 
-```
+```jsx
 const Toggle: Poly.Component<typeof DEFAULT_TOGGLE, ToggleProps> =
   React.forwardRef(
     <T extends React.ElementType = typeof DEFAULT_TOGGLE>(
@@ -39,24 +39,20 @@ const Toggle: Poly.Component<typeof DEFAULT_TOGGLE, ToggleProps> =
 
 이를 통해, 다음과 같이 이용할 수 있습니다.
 
-```
+```jsx
 function Home() {
   const [state, setState] = useState(false);
   return (
     <>
-      <Toggle
-        pressed={state}
-        onPressedChange={(pressed) => setState(pressed)}
-      />
+      <Toggle pressed={state} onPressedChange={(pressed) => setState(pressed)} />
     </>
   );
 }
-
 ```
 
 - useControlled의 value, onValueChange를 이용할 경우 외부의 상태를 이용할 수 있습니다.
 
-```
+```jsx
 function Home() {
   return (
     <>

--- a/packages/useControlled/README.md
+++ b/packages/useControlled/README.md
@@ -1,0 +1,73 @@
+# `over-ui/useControlled`
+
+`useControlled` 패키지는, `over-ui` 에서 상태를 관리하는 훅입니다.
+내부에서만 사용하는 패키지입니다.
+
+## Usage
+
+```
+const Toggle: Poly.Component<typeof DEFAULT_TOGGLE, ToggleProps> =
+  React.forwardRef(
+    <T extends React.ElementType = typeof DEFAULT_TOGGLE>(
+      props: Poly.Props<T, ToggleProps>,
+      ref: Poly.Ref<T>,
+    ) => {
+      const {
+        onClick,
+        onKeyDown,
+        onPressedChange,
+        disabled = false,
+        children,
+        defaultPressed = false,
+        pressed: pressedProp,
+        as,
+        ...restProps
+      } = props;
+
+      const [pressed, setPressed] = useControlled({
+        value: pressedProp,
+        defaultValue: defaultPressed,
+        onChange: onPressedChange,
+      });
+
+      ...
+      );
+    },
+  );
+
+```
+
+이를 통해, 다음과 같이 이용할 수 있습니다.
+
+```
+function Home() {
+  const [state, setState] = useState(false);
+  return (
+    <>
+      <Toggle
+        pressed={state}
+        onPressedChange={(pressed) => setState(pressed)}
+      />
+    </>
+  );
+}
+
+```
+
+- useControlled의 value, onValueChange를 이용할 경우 외부의 상태를 이용할 수 있습니다.
+
+```
+function Home() {
+  return (
+    <>
+      <Toggle
+        defaultPressed={false}
+        onPressedChange={(pressed) => console.log(pressed)}
+        // false
+      />
+    </>
+  );
+}
+```
+
+- 외부의 상태를 정의하지 않고, 내부의 상태만을 활용할 수 있습니다.

--- a/packages/useControlled/package.json
+++ b/packages/useControlled/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@over-ui/useControlled",
-  "version": "1.1.0",
+  "name": "@over-ui/use-controlled",
+  "version": "1.0.0",
   "license": "MIT",
   "contributors": [
     "otterp012 <otterp012@gmail.com>",

--- a/packages/useControlled/package.json
+++ b/packages/useControlled/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@over-ui/useControlled",
+  "version": "1.1.0",
+  "license": "MIT",
+  "contributors": [
+    "otterp012 <otterp012@gmail.com>",
+    "lv0314 <luzverde0314@gmail.com>"
+  ],
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:typings && rollup -c ../../rollup.config.mjs",
+    "watch": "rollup -c ../../rollup.config.mjs -w",
+    "build:typings": "tsc -p ./tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/over-ui/unstyled/tree/main#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/over-ui/unstyled.git"
+  },
+  "bugs": {
+    "url": "https://github.com/over-ui/unstyled/issues"
+  }
+}

--- a/packages/useControlled/src/index.ts
+++ b/packages/useControlled/src/index.ts
@@ -1,0 +1,1 @@
+export * from './useControlled';

--- a/packages/useControlled/src/useControlled.ts
+++ b/packages/useControlled/src/useControlled.ts
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+type UseControlledProps<T> = {
+  value?: T;
+  defaultValue?: T;
+  valueOnChange?: (value: T) => void;
+};
+
+export function useControlled<T>({
+  value: valueProp,
+  defaultValue,
+  valueOnChange,
+}: UseControlledProps<T>) {
+  const [internalState, setInternalState] = React.useState(defaultValue);
+  const controlled = valueProp !== undefined;
+  const value = controlled ? valueProp : internalState;
+
+  const setValue = (next: React.SetStateAction<T>) => {
+    const setter = next as (prevState?: T) => T;
+    const nextValue = typeof next === 'function' ? setter(value) : next;
+
+    if (!controlled) {
+      setInternalState(nextValue);
+    }
+    valueOnChange?.(nextValue);
+  };
+
+  return [value, setValue] as [T, React.Dispatch<React.SetStateAction<T>>];
+}

--- a/packages/useControlled/tsconfig.json
+++ b/packages/useControlled/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/index.ts"],
+  "compilerOptions": {
+    "declarationDir": "./dist"
+  }
+}


### PR DESCRIPTION
closes #41 

## Description
대부분의 컴포넌트에서 사용될 수 있는 `useControlled` 과 `mergeRefs` 를 추가합니다.

### useControlled

```jsx
const Toggle: Poly.Component<typeof DEFAULT_TOGGLE, ToggleProps> =
  React.forwardRef(
    <T extends React.ElementType = typeof DEFAULT_TOGGLE>(
      props: Poly.Props<T, ToggleProps>,
      ref: Poly.Ref<T>,
    ) => {
      const {
        onClick,
        onKeyDown,
        onPressedChange,
        disabled = false,
        children,
        defaultPressed = false,
        pressed: pressedProp,
        as,
        ...restProps
      } = props;

      const [pressed, setPressed] = useControlled({
        value: pressedProp,
        defaultValue: defaultPressed,
        onChange: onPressedChange,
      });

      ...
      );
    },
  );

```

이를 통해, 다음과 같이 이용할 수 있습니다.

```jsx
function Home() {
  const [state, setState] = useState(false);
  return (
    <>
      <Toggle
        pressed={state}
        onPressedChange={(pressed) => setState(pressed)}
      />
    </>
  );
}

```

- useControlled의 value, onValueChange를 이용할 경우 외부의 상태를 이용할 수 있습니다.

```jsx
function Home() {
  return (
    <>
      <Toggle
        defaultPressed={false}
        onPressedChange={(pressed) => console.log(pressed)}
        // false
      />
    </>
  );
}
```

- 외부의 상태를 정의하지 않고, 내부의 상태만을 활용할 수 있습니다.

### mergeRefs
```jsx
const Toggle = React.forwardRef((props, ref) => {
  const innerRef = React.useRef(null);
  return <button ref={mergeRefs([innerRef, ref])}>토글</button>;
});
```

위와 같은 상황에서 주로 사용합니다. 부모로부터 내려받은 `ref`와 내부에 있는 `innerRef`를 병합할 수 있습니다.

```jsx
const Toggle = React.forwardRef((props, ref) => {
  return <button ref={mergeRefs([(node) => node?.focus(), ref])}>토글</button>;
});
```

`ref Callback`의 사용또한 가능합니다.
