### PR TITLE
Feature/dismissableLayer #37

### DIFF
--- a/packages/dismissableLayer/README.md
+++ b/packages/dismissableLayer/README.md
@@ -1,0 +1,10 @@
+# `over-test`
+
+> TODO: description
+
+## Usage
+
+```
+`package.json`에 `private` 옵션을 `false` 로 바꿔 주셔야 합니다.
+이 템플릿은, 배포용이 아닌 내부에서 사용하기 위에 적용된 파일입니다.
+```

--- a/packages/dismissableLayer/README.md
+++ b/packages/dismissableLayer/README.md
@@ -1,10 +1,7 @@
-# `over-test`
+# `over-dismissableLayer`
 
-> TODO: description
+DismissableLayer는 모달 컴포넌트가 닫히는 동작을 위해 만들어진 레이어 컴포넌트 입니다
+모달을 만들 때 마다 반복되는 부분이 있고, 관심사 분리를 위해 구현하게 됐습니다
+모달의 content가 되는 부분을 감싸서 해당 부분이 아닌 부분을 클릭하거나, 포커스를 내보내거나, escape 키를 눌렀을 경우 onDismiss 함수를 실행시켜 모달을 닫는 방법으로 사용할 수 있습니다
 
 ## Usage
-
-```
-`package.json`에 `private` 옵션을 `false` 로 바꿔 주셔야 합니다.
-이 템플릿은, 배포용이 아닌 내부에서 사용하기 위에 적용된 파일입니다.
-```

--- a/packages/dismissableLayer/README.md
+++ b/packages/dismissableLayer/README.md
@@ -1,7 +1,95 @@
 # `over-dismissableLayer`
 
-DismissableLayer는 모달 컴포넌트가 닫히는 동작을 위해 만들어진 레이어 컴포넌트 입니다
-모달을 만들 때 마다 반복되는 부분이 있고, 관심사 분리를 위해 구현하게 됐습니다
-모달의 content가 되는 부분을 감싸서 해당 부분이 아닌 부분을 클릭하거나, 포커스를 내보내거나, escape 키를 눌렀을 경우 onDismiss 함수를 실행시켜 모달을 닫는 방법으로 사용할 수 있습니다
+`DismissableLayer`는 모달 컴포넌트의 닫히는 동작을 위해 만들어진 레이어 컴포넌트 입니다
+모달을 만들 때 마다 처리에 대한 반복되는 부분이 발생하기때문에 관심사의 분리를 위해 구현하게 됐습니다
+모달의 content가 되는 부분을 감싸서 `dismissableLayer가 아닌 부분을 클릭하거나, 포커스를 내보내거나, escape 키를 눌렀을 경우` onDismiss 함수를 실행시켜 모달을 닫는 방법으로 사용할 수 있습니다
 
 ## Usage
+
+```tsx
+import * as React from 'react';
+import { Poly } from '@over-ui/core';
+import { DismissableLayer } from '@over-ui/dismissableLayer';
+
+//...DemoDialog
+type DemoDialogContentImplElement = React.ElementRef<typeof DismissableLayer>;
+type DemoDismissableLayerProps = {
+  children?: React.ReactNode;
+  disableOutsidePointerEvents?: boolean;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onPointerDownOutside?: (event: PointerEvent) => void;
+  onFocusOutside?: (event: FocusEvent) => void;
+  onInteractOutside?: (event: PointerEvent | FocusEvent) => void;
+  onDismiss?: () => void;
+};
+type DemoDialogContentImplProps = React.HTMLProps<HTMLDivElement> &
+  Omit<DismissableLayerProps, 'onDismiss'>;
+
+const DEMO_DIALOG_CONTENT_IMPL_TAG = 'div';
+
+const DemoDialogContentImpl: Poly.Component<
+  typeof DEMO_DIALOG_CONTENT_IMPL_TAG,
+  DemoDialogContentImplProps
+> = React.forwardRef(
+  <T extends React.ElementType = typeof DEMO_DIALOG_CONTENT_IMPL_TAG>(
+    props: Poly.Props<T, DemoDialogContentImplProps>,
+    forwardedRef: Poly.Ref<T>
+  ) => {
+    const { as, ...contentProps } = props;
+    const context = useDialogContext();
+    const contentRef = React.useRef<HTMLDivElement | null>(null);
+
+    return (
+      <>
+        <DismissableLayer
+          role="dialog"
+          id={context.contentId}
+          aria-describedby={context.descriptionId}
+          aria-labelledby={context.titleId}
+          data-state={getState(context.open)}
+          {...contentProps}
+          ref={contentRef}
+          onDismiss={() => {
+            context?.onOpenChange?.(false);
+          }}
+        />
+      </>
+    );
+  }
+);
+
+type DemoDialogContentModalElement = DemoDialogContentImplElement;
+type DemoDialogContentModalProps = DemoDialogContentImplProps;
+
+const DemoDialogContentModal = React.forwardRef<
+  DemoDialogContentModalElement,
+  DemoDialogContentModalProps
+>((props, forwardedRef) => {
+  const { as, ...dialogContentProps } = props;
+  const context = useDialogContext();
+  const contentRef = React.useRef<HTMLDivElement>(null);
+
+  const handlePointerDownOutside = (event: PointerEvent) => {
+    const ctrlLeftClick = event.button === 0 && event.ctrlKey === true;
+    const isRightClick = event.button === 2 || ctrlLeftClick;
+
+    //우클릭 모달 닫기 방지
+    if (isRightClick) event.preventDefault();
+  };
+
+  const handleFocusOutside = (event: FocusEvent) => {
+    event.preventDefault();
+  };
+
+  return (
+    <DialogContentImpl
+      {...dialogContentProps}
+      ref={contentRef}
+      onPointerDownOutside={composeEvent(handlePointerDownOutside, props.onPointerDownOutside)}
+      onFocusOutside={composeEvent(handleFocusOutside, props.onFocusOutside)}
+    />
+  );
+});
+
+//...
+```

--- a/packages/dismissableLayer/package.json
+++ b/packages/dismissableLayer/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@over-ui/dismissableLayer",
+  "version": "1.0.0",
+  "private": false,
+  "license": "MIT",
+  "contributors": [
+    "otterp012 <otterp012@gmail.com>",
+    "lv0314 <luzverde0314@gmail.com>"
+  ],
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:typings && rollup -c ../../rollup.config.mjs",
+    "watch": "rollup -c ../../rollup.config.mjs -w",
+    "build:typings": "tsc -p ./tsconfig.json",
+    "clean": "rm -rf dist",
+    "lint": "eslint ./src"
+  },
+  "dependencies": {
+    "@over-ui/core": "*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/over-ui/unstyled/tree/main#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/over-ui/unstyled.git"
+  },
+  "bugs": {
+    "url": "https://github.com/over-ui/unstyled/issues"
+  }
+}

--- a/packages/dismissableLayer/package.json
+++ b/packages/dismissableLayer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@over-ui/dismissableLayer",
+  "name": "@over-ui/dismissable-layer",
   "version": "1.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/dismissableLayer/package.json
+++ b/packages/dismissableLayer/package.json
@@ -26,7 +26,8 @@
     "lint": "eslint ./src"
   },
   "dependencies": {
-    "@over-ui/core": "*"
+    "@over-ui/core": "*",
+    "@over-ui/merge-refs": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dismissableLayer/src/DismissableLayer.tsx
+++ b/packages/dismissableLayer/src/DismissableLayer.tsx
@@ -104,6 +104,42 @@ const DismissableLayer: Poly.Component<typeof DISMISSABLE_LAYER_TAG, Dismissable
         };
       }, [document, node]);
 
+      /* keyDown handler */
+      const handleEscapeKeyDown = (event: KeyboardEvent) => {
+        if (!node) return;
+        if (event.key !== 'Escape') return;
+
+        const layers = Array.from(context.layers);
+        const curIndex = node ? layers.indexOf(node) : -1;
+        const isHighestLayer = curIndex === context.layers.size - 1;
+
+        if (!isHighestLayer) return;
+
+        onEscapeKeyDown?.(event);
+
+        if (!event.defaultPrevented) {
+          event.preventDefault();
+          onDismiss?.();
+        }
+      };
+
+      React.useEffect(() => {
+        document.addEventListener('keydown', handleEscapeKeyDown);
+        return () => {
+          document.removeEventListener('keydown', handleEscapeKeyDown);
+        };
+      }, [document, node]);
+
+      React.useEffect(() => {
+        if (!node) return;
+        context.layers.add(node);
+
+        return () => {
+          if (!node) return;
+          context.layers.delete(node);
+        };
+      }, [node, document, context]);
+
       React.useEffect(() => {
         if (!node) return;
         context.layers.add(node);

--- a/packages/dismissableLayer/src/DismissableLayer.tsx
+++ b/packages/dismissableLayer/src/DismissableLayer.tsx
@@ -76,6 +76,34 @@ const DismissableLayer: Poly.Component<typeof DISMISSABLE_LAYER_TAG, Dismissable
         };
       }, [document, node]);
 
+      /* focusin handler */
+      const handleFocusOutside = (event: FocusEvent) => {
+        if (!node) return;
+
+        const target = event.target as HTMLElement;
+
+        const layers = Array.from(context.layers);
+        const curIndex = node ? layers.indexOf(node) : -1;
+        const isHighestLayer = curIndex === context.layers.size - 1;
+
+        //포커스가 이동 된 target이 node 안의 엘리먼트인지 판단
+        const isFocusedOnBranch =
+          dismissableLayerRef.current?.contains(target) ||
+          dismissableLayerRef.current?.parentElement?.contains(target);
+
+        if (!isHighestLayer || isFocusedOnBranch) return;
+        onFocusOutside?.(event);
+        onInteractOutside?.(event);
+        if (!event.defaultPrevented) onDismiss?.();
+      };
+
+      React.useEffect(() => {
+        document.addEventListener('focusin', handleFocusOutside);
+        return () => {
+          document.removeEventListener('focusin', handleFocusOutside);
+        };
+      }, [document, node]);
+
       React.useEffect(() => {
         if (!node) return;
         context.layers.add(node);

--- a/packages/dismissableLayer/src/DismissableLayer.tsx
+++ b/packages/dismissableLayer/src/DismissableLayer.tsx
@@ -84,7 +84,7 @@ const DismissableLayer: Poly.Component<typeof DISMISSABLE_LAYER_TAG, Dismissable
 
         const isFocusedOnBranch = node.contains(target) || node.parentElement?.contains(target);
 
-        if (!isHighestLayer || isFocusedOnBranch) return;
+        if (!isHighestLayer || isFocusedOnBranch || !disableOutsidePointerEvents) return;
 
         onFocusOutside?.(event);
         onInteractOutside?.(event);

--- a/packages/dismissableLayer/src/DismissableLayer.tsx
+++ b/packages/dismissableLayer/src/DismissableLayer.tsx
@@ -1,5 +1,81 @@
 import * as React from 'react';
+import { Poly } from '@over-ui/core';
 
-export const DismissableLayer = () => {
-  return <button>수정123</button>;
+/* -------------------------------------------------------------------------------------------------
+ * DismissableLayer
+ * -----------------------------------------------------------------------------------------------*/
+
+type DismissableLayerProps = {
+  children?: React.ReactNode;
+  disableOutsidePointerEvents?: boolean;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onPointerDownOutside?: (event: PointerEvent) => void;
+  onFocusOutside?: (event: FocusEvent) => void;
+  onInteractOutside?: (event: PointerEvent | FocusEvent) => void;
+  onDismiss?: () => void;
 };
+
+const DISMISSABLE_LAYER_TAG = 'div';
+
+const DismissableLayerContext = React.createContext({
+  //DismissableLayer가 생성되면 layers에 넣고
+  //해당 layer가 최상위에 위치한 layer인지 판단하고, 최상위 layer가 아닐 경우 return
+  layers: new Set<HTMLDivElement>(),
+});
+
+const DismissableLayer: Poly.Component<typeof DISMISSABLE_LAYER_TAG, DismissableLayerProps> =
+  React.forwardRef(
+    <T extends React.ElementType = typeof DISMISSABLE_LAYER_TAG>(
+      props: Poly.Props<T, DismissableLayerProps>,
+      forwardedRef: Poly.Ref<T>
+    ) => {
+      const {
+        as,
+        children,
+        disableOutsidePointerEvents = true,
+        onEscapeKeyDown,
+        onPointerDownOutside,
+        onFocusOutside,
+        onInteractOutside,
+        onDismiss,
+        ...layerProps
+      } = props;
+      const Tag = as || DISMISSABLE_LAYER_TAG;
+      const context = React.useContext(DismissableLayerContext);
+      const dismissableLayerRef = React.useRef<HTMLDivElement | null>(null);
+      const [node, setNode] = React.useState<HTMLDivElement | null>(null);
+      const document = globalThis?.document;
+
+      React.useEffect(() => {
+        setNode(dismissableLayerRef.current);
+      }, []);
+
+      React.useEffect(() => {
+        if (!node) return;
+        context.layers.add(node);
+
+        return () => {
+          if (!node) return;
+          context.layers.delete(node);
+        };
+      }, [node, document, context]);
+
+      return (
+        <Tag ref={dismissableLayerRef} {...layerProps}>
+          {children}
+        </Tag>
+      );
+    }
+  );
+
+DismissableLayer.displayName = 'DISMISSABLE_LAYER';
+
+const Root = DismissableLayer;
+
+export {
+  DismissableLayer,
+  //
+  Root,
+};
+
+export type { DismissableLayerProps };

--- a/packages/dismissableLayer/src/DismissableLayer.tsx
+++ b/packages/dismissableLayer/src/DismissableLayer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Poly } from '@over-ui/core';
+import { Poly, useSafeContext } from '@over-ui/core';
 
 /* -------------------------------------------------------------------------------------------------
  * DismissableLayer
@@ -41,7 +41,7 @@ const DismissableLayer: Poly.Component<typeof DISMISSABLE_LAYER_TAG, Dismissable
         ...layerProps
       } = props;
       const Tag = as || DISMISSABLE_LAYER_TAG;
-      const context = React.useContext(DismissableLayerContext);
+      const context = useSafeContext(DismissableLayerContext, 'DismissableLayer');
       const dismissableLayerRef = React.useRef<HTMLDivElement | null>(null);
       const [node, setNode] = React.useState<HTMLDivElement | null>(null);
       const document = globalThis?.document;

--- a/packages/dismissableLayer/src/DismissableLayer.tsx
+++ b/packages/dismissableLayer/src/DismissableLayer.tsx
@@ -50,6 +50,32 @@ const DismissableLayer: Poly.Component<typeof DISMISSABLE_LAYER_TAG, Dismissable
         setNode(dismissableLayerRef.current);
       }, []);
 
+      /* pointerdown handler */
+      const handlePointerDownOutside = (event: PointerEvent) => {
+        if (!node) return;
+
+        const target = event.target as HTMLElement;
+
+        const layers = Array.from(context.layers);
+        const curIndex = node ? layers.indexOf(node) : -1;
+        const isHighestLayer = curIndex === context.layers.size - 1;
+
+        //클릭한 target이 node 안의 엘리먼트인지 판단
+        const isPointerDownOnBranch = dismissableLayerRef.current?.contains(target);
+        if (!isHighestLayer || isPointerDownOnBranch || !disableOutsidePointerEvents) return;
+
+        onPointerDownOutside?.(event);
+        onInteractOutside?.(event);
+        if (!event.defaultPrevented) onDismiss?.();
+      };
+
+      React.useEffect(() => {
+        document.addEventListener('pointerdown', handlePointerDownOutside);
+        return () => {
+          document.removeEventListener('pointerdown', handlePointerDownOutside);
+        };
+      }, [document, node]);
+
       React.useEffect(() => {
         if (!node) return;
         context.layers.add(node);

--- a/packages/dismissableLayer/src/DismissableLayer.tsx
+++ b/packages/dismissableLayer/src/DismissableLayer.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export const DismissableLayer = () => {
+  return <button>수정123</button>;
+};

--- a/packages/dismissableLayer/src/DismissableLayer.tsx
+++ b/packages/dismissableLayer/src/DismissableLayer.tsx
@@ -20,7 +20,7 @@ const DISMISSABLE_LAYER_TAG = 'div';
 
 const DismissableLayerContext = React.createContext({
   //DismissableLayer가 생성되면 layers에 add
-  //layer가 여러겹일 경우, 해당 layer가 최상위에 위치한 layer인지 판단하고, 최상위 layer가 아닐 경우 return
+  //해당 layer가 최상위에 위치한 layer인지 판단하고, 최상위 layer가 아닐 경우 return
   layers: new Set<HTMLDivElement>(),
 });
 
@@ -43,13 +43,9 @@ const DismissableLayer: Poly.Component<typeof DISMISSABLE_LAYER_TAG, Dismissable
       } = props;
       const Tag = as || DISMISSABLE_LAYER_TAG;
       const context = useSafeContext(DismissableLayerContext, 'DismissableLayer');
-      const dismissableLayerRef = React.useRef<HTMLDivElement | null>(null);
       const [node, setNode] = React.useState<HTMLDivElement | null>(null);
+      const mergedRef = mergeRefs([(node: HTMLDivElement | null) => setNode(node), forwardedRef]);
       const document = globalThis?.document;
-
-      React.useEffect(() => {
-        setNode(dismissableLayerRef.current);
-      }, []);
 
       /* pointerdown handler */
       const handlePointerDownOutside = (event: PointerEvent) => {
@@ -61,7 +57,7 @@ const DismissableLayer: Poly.Component<typeof DISMISSABLE_LAYER_TAG, Dismissable
         const curIndex = node ? layers.indexOf(node) : -1;
         const isHighestLayer = curIndex === context.layers.size - 1;
 
-        const isPointerDownOnBranch = dismissableLayerRef.current?.contains(target);
+        const isPointerDownOnBranch = node.contains(target);
         if (!isHighestLayer || isPointerDownOnBranch || !disableOutsidePointerEvents) return;
 
         onPointerDownOutside?.(event);
@@ -86,9 +82,7 @@ const DismissableLayer: Poly.Component<typeof DISMISSABLE_LAYER_TAG, Dismissable
         const curIndex = node ? layers.indexOf(node) : -1;
         const isHighestLayer = curIndex === context.layers.size - 1;
 
-        const isFocusedOnBranch =
-          dismissableLayerRef.current?.contains(target) ||
-          dismissableLayerRef.current?.parentElement?.contains(target);
+        const isFocusedOnBranch = node.contains(target) || node.parentElement?.contains(target);
 
         if (!isHighestLayer || isFocusedOnBranch) return;
 
@@ -141,7 +135,7 @@ const DismissableLayer: Poly.Component<typeof DISMISSABLE_LAYER_TAG, Dismissable
       }, [node, document, context]);
 
       return (
-        <Tag ref={mergeRefs([dismissableLayerRef, forwardedRef])} {...layerProps}>
+        <Tag ref={mergedRef} {...layerProps}>
           {children}
         </Tag>
       );

--- a/packages/dismissableLayer/src/index.ts
+++ b/packages/dismissableLayer/src/index.ts
@@ -1,0 +1,1 @@
+export * from './DismissableLayer';

--- a/packages/dismissableLayer/tsconfig.json
+++ b/packages/dismissableLayer/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/index.ts"],
+  "compilerOptions": {
+    "declarationDir": "./dist"
+  }
+}


### PR DESCRIPTION
closes #37

## Description
`DismissableLayer`는 `over-ui`내부에서만 사용되는 패키지입니다.

`DismissableLayer`는 모달 컴포넌트의 닫히는 동작을 위해 만들어진 레이어 컴포넌트 입니다
모달을 만들 때 마다 처리에 대한 반복되는 부분이 발생하기때문에 관심사의 분리를 위해 구현하게 됐습니다
모달의 content가 되는 부분을 감싸서 `dismissableLayer가 아닌 부분을 클릭하거나, 포커스를 내보내거나, escape 키를 눌렀을 경우` onDismiss 함수를 실행시켜 모달을 닫는 방법으로 사용할 수 있습니다

## Usage
```tsx
import * as React from 'react';
import { Poly } from '@over-ui/core';
import { DismissableLayer } from '@over-ui/dismissableLayer';

//...DemoDialog
type DemoDialogContentImplElement = React.ElementRef<typeof DismissableLayer>;
type DemoDismissableLayerProps = {
  children?: React.ReactNode;
  disableOutsidePointerEvents?: boolean;
  onEscapeKeyDown?: (event: KeyboardEvent) => void;
  onPointerDownOutside?: (event: PointerEvent) => void;
  onFocusOutside?: (event: FocusEvent) => void;
  onInteractOutside?: (event: PointerEvent | FocusEvent) => void;
  onDismiss?: () => void;
};
type DemoDialogContentImplProps = React.HTMLProps<HTMLDivElement> &
  Omit<DismissableLayerProps, 'onDismiss'>;

const DEMO_DIALOG_CONTENT_IMPL_TAG = 'div';

const DemoDialogContentImpl: Poly.Component<
  typeof DEMO_DIALOG_CONTENT_IMPL_TAG,
  DemoDialogContentImplProps
> = React.forwardRef(
  <T extends React.ElementType = typeof DEMO_DIALOG_CONTENT_IMPL_TAG>(
    props: Poly.Props<T, DemoDialogContentImplProps>,
    forwardedRef: Poly.Ref<T>
  ) => {
    const { as, ...contentProps } = props;
    const context = useDialogContext();
    const contentRef = React.useRef<HTMLDivElement | null>(null);

    return (
      <>
        <DismissableLayer
          role="dialog"
          id={context.contentId}
          aria-describedby={context.descriptionId}
          aria-labelledby={context.titleId}
          data-state={getState(context.open)}
          {...contentProps}
          ref={contentRef}
          onDismiss={() => {
            context?.onOpenChange?.(false);
          }}
        />
      </>
    );
  }
);

type DemoDialogContentModalElement = DemoDialogContentImplElement;
type DemoDialogContentModalProps = DemoDialogContentImplProps;

const DemoDialogContentModal = React.forwardRef<
  DemoDialogContentModalElement,
  DemoDialogContentModalProps
>((props, forwardedRef) => {
  const { as, ...dialogContentProps } = props;
  const context = useDialogContext();
  const contentRef = React.useRef<HTMLDivElement>(null);

  const handlePointerDownOutside = (event: PointerEvent) => {
    const ctrlLeftClick = event.button === 0 && event.ctrlKey === true;
    const isRightClick = event.button === 2 || ctrlLeftClick;

    //우클릭 모달 닫기 방지
    if (isRightClick) event.preventDefault();
  };

  const handleFocusOutside = (event: FocusEvent) => {
    event.preventDefault();
  };

  return (
    <DialogContentImpl
      {...dialogContentProps}
      ref={contentRef}
      onPointerDownOutside={composeEvent(handlePointerDownOutside, props.onPointerDownOutside)}
      onFocusOutside={composeEvent(handleFocusOutside, props.onFocusOutside)}
    />
  );
});

//...
```