### PR TITLE
feat: use-id #50

### DIFF
--- a/packages/useId/README.md
+++ b/packages/useId/README.md
@@ -1,0 +1,4 @@
+# `over-ui/use-id`
+
+`React 18`버전에서 등장한 `useId` 훅이 존재하지 않을 시 커스텀훅으로 대체하기 위한 훅입니다.
+`useId`가 존재한다면, `React.useId`를 사용하고 존재하지 않는다면 `useSafeId`를 사용해 고유한 `id`를 생성합니다.

--- a/packages/useId/package.json
+++ b/packages/useId/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@over-ui/use-id",
+  "version": "1.0.0",
+  "license": "MIT",
+  "contributors": [
+    "otterp012 <otterp012@gmail.com>",
+    "lv0314 <luzverde0314@gmail.com>"
+  ],
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:typings && rollup -c ../../rollup.config.mjs",
+    "watch": "rollup -c ../../rollup.config.mjs -w",
+    "build:typings": "tsc -p ./tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/over-ui/unstyled/tree/main#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/over-ui/unstyled.git"
+  },
+  "bugs": {
+    "url": "https://github.com/over-ui/unstyled/issues"
+  }
+}

--- a/packages/useId/src/index.ts
+++ b/packages/useId/src/index.ts
@@ -1,0 +1,1 @@
+export * from './useId';

--- a/packages/useId/src/useId.ts
+++ b/packages/useId/src/useId.ts
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+const prefix = 'over-id-';
+
+const randomId = () => `${prefix}${Math.random().toString(36).slice(2, 11)}`;
+
+const useReactId: () => string | undefined =
+  (React as any)['useId'.toString()] || (() => undefined);
+
+const getReactId = () => {
+  const id = useReactId();
+  return id;
+};
+
+const useSafeId = () => {
+  const [uniqueId, setUniqueId] = React.useState('');
+
+  React.useEffect(() => {
+    setUniqueId(randomId());
+  }, []);
+
+  return uniqueId;
+};
+
+export const useId = () => {
+  return getReactId() ?? useSafeId();
+};

--- a/packages/useId/tsconfig.json
+++ b/packages/useId/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/index.ts"],
+  "compilerOptions": {
+    "declarationDir": "./dist"
+  }
+}


### PR DESCRIPTION

# `over-ui/use-id`

`React 18`버전에서 등장한 `useId` 훅이 존재하지 않을 시 커스텀훅으로 대체하기 위한 훅입니다.
`useId`가 존재한다면, `React.useId`를 사용하고 존재하지 않는다면 `useSafeId`를 사용해 고유한 `id`를 생성합니다.

## 추후 계획
`useEffect`를 `next` 환경이 아닐 시 `useLayoutEffect`로 변경하는 부분을 수정할 필요가 있습니다.