### PR TITLE
Feature/roving #23

### DIFF
--- a/packages/createRovingContext/README.md
+++ b/packages/createRovingContext/README.md
@@ -1,0 +1,74 @@
+# `over-ui/createRovingContext`
+
+`createRovingContext` 패키지는, `over-ui` 패키기 내부에서 사용하는 훅입니다.
+`radio, toggle` 컴포넌트를 작성할 때의 접근성 규칙을 준수하기 위해 `roving TabIndex`를 구현합니다.
+
+## Usage
+
+```
+// group 요소
+const Container: Poly.Component<typeof DEFAULT_ROOT, ContainerProps> =
+  React.forwardRef(
+    <T extends React.ElementType = typeof DEFAULT_ROOT>(
+      props: Poly.Props<T, ContainerProps>,
+      ref: Poly.Ref<T>,
+    ) => {
+      const {
+        children,
+        pressed,
+        as,
+        onFocus: theirOnFocus,
+        onKeyDown: theirOnKeyDown,
+        ...restProps
+      } = props;
+      const containerRef = React.useRef<HTMLDivElement>(null);
+      const { handleRovingKeyDown, handleRovingFocus } = useRoving();
+
+      // 그룹 요소에, rovingKeyDown, RovingFocus를 등록합니다.
+      return (
+        <Tag
+          role='group'
+          onFocus={composeEvent(
+            handleRovingFocus({ dom: containerRef, selected: pressed }),
+            theirOnFocus,
+          )}
+          onKeyDown={composeEvent(handleRovingKeyDown, theirOnKeyDown)}
+          tabIndex={0}
+          // 이 컴포넌트는 반드시, `focus` 될 수 있어야 합니다.
+          // 접근성으로 인해 포커스가 되는 즉시 내부의 요소에 포커스가 이동합니다.
+          ref={mergeRefs([containerRef, ref])}
+          {...restProps}
+        >
+          {children}
+        </Tag>
+      );
+    },
+  );
+
+// ---------
+
+export const Item: Poly.Component<typeof DEFAULT_ITEM, ItemProps> =
+  React.forwardRef(
+    <T extends React.ElementType = typeof DEFAULT_ITEM>(
+      props: Poly.Props<T, ItemProps>,
+      ref: Poly.Ref<T>,
+    ) => {
+      const { children, value, disabled = false, ...restProps } = props;
+      const ItemRef = React.useRef<HTMLButtonElement>(null);
+
+      const { pressedValue, multiple, setValue, deleteValue } = useSafeContext(
+        ToggleContext,
+        ITEM_DISPLAY_NAME,
+      );
+
+      const { useRegister } = useRoving();
+
+      useRegister(value, {
+        dom: ItemRef,
+        value,
+        disabled,
+      });
+      ....
+      // item 요소에서 register를 진행합니다.
+
+```

--- a/packages/createRovingContext/README.md
+++ b/packages/createRovingContext/README.md
@@ -7,6 +7,7 @@
 
 ```
 // 사용 전에, rovingProvider로 사용해야 하는 컴포넌트를 묶어주세요.
+
 const {rovingProvider, useRoving} = createRovingContext();
 // group 요소
 const Container: Poly.Component<typeof DEFAULT_ROOT, ContainerProps> =
@@ -37,7 +38,7 @@ const Container: Poly.Component<typeof DEFAULT_ROOT, ContainerProps> =
           onKeyDown={composeEvent(handleRovingKeyDown, theirOnKeyDown)}
           tabIndex={0}
           // 이 컴포넌트는 반드시, `focus` 될 수 있어야 합니다.
-          // 접근성으로 인해 포커스가 되는 즉시 내부의 요소에 포커스가 이동합니다.
+          // 이부분에 `focus` 되었을 때에 `tabIndex`를 재조정하기 때문입니다.
           ref={mergeRefs([containerRef, ref])}
           {...restProps}
         >

--- a/packages/createRovingContext/README.md
+++ b/packages/createRovingContext/README.md
@@ -1,4 +1,4 @@
-# `over-ui/createRovingContext`
+# `over-ui/create-roving-context`
 
 `createRovingContext` 패키지는, `over-ui` 패키기 내부에서 사용하는 훅입니다.
 `radio, toggle` 컴포넌트를 작성할 때의 접근성 규칙을 준수하기 위해 `roving TabIndex`를 구현합니다.

--- a/packages/createRovingContext/README.md
+++ b/packages/createRovingContext/README.md
@@ -6,6 +6,8 @@
 ## Usage
 
 ```
+// 사용 전에, rovingProvider로 사용해야 하는 컴포넌트를 묶어주세요.
+const {rovingProvider, useRoving} = createRovingContext();
 // group 요소
 const Container: Poly.Component<typeof DEFAULT_ROOT, ContainerProps> =
   React.forwardRef(

--- a/packages/createRovingContext/package.json
+++ b/packages/createRovingContext/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@over-ui/create-roving-context",
+  "version": "1.0.0",
+  "license": "MIT",
+  "contributors": [
+    "otterp012 <otterp012@gmail.com>",
+    "lv0314 <luzverde0314@gmail.com>"
+  ],
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:typings && rollup -c ../../rollup.config.mjs",
+    "watch": "rollup -c ../../rollup.config.mjs -w",
+    "build:typings": "tsc -p ./tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/over-ui/unstyled/tree/main#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/over-ui/unstyled.git"
+  },
+  "bugs": {
+    "url": "https://github.com/over-ui/unstyled/issues"
+  }
+}

--- a/packages/createRovingContext/package.json
+++ b/packages/createRovingContext/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@over-ui/create-roving-context",
   "version": "1.0.0",
+  "private": false,
   "license": "MIT",
   "contributors": [
     "otterp012 <otterp012@gmail.com>",

--- a/packages/createRovingContext/src/createRovingContext.tsx
+++ b/packages/createRovingContext/src/createRovingContext.tsx
@@ -1,0 +1,162 @@
+/* eslint-disable react/prop-types */
+import * as React from 'react';
+import * as RovingUtils from './utils';
+
+const { getCurrentFocused, getComputedIndex, setNodeFocusable, setNodeUnFocusable, setNodeFocus } =
+  RovingUtils;
+
+const ROVING_KEYS = {
+  NEXT: ['ArrowRight', 'ArrowUp'],
+  PREV: ['ArrowLeft', 'ArrowDown'],
+  HOME: ['Home'],
+  END: ['End'],
+  CLOSE: ['Tab'],
+};
+
+type RovingContext = {
+  /**
+   * roving focus가 필요한 요소들의 dom, value, disabled를 모으기 위한 hook입니다.
+   */
+  useRegister: (
+    id: string,
+    props: {
+      dom: React.RefObject<HTMLElement>;
+      value: string;
+      disabled: boolean;
+    }
+  ) => void;
+
+  /**
+   * roving focus의 keyboard navigation을 지원하는 함수입니다.
+   * `roving` 요소들을 묶고 있는 `group` 요소에서 사용합니다.
+   */
+  handleRovingKeyDown: (e: React.KeyboardEvent) => void;
+
+  /**
+   * roving focus를 초기화해주는 함수입니다.
+   *
+   * 요소들을 묶고 있는 `role`이 `group`인 컴포넌트의 `focus`이벤트로 등록합니다.
+   *
+   * `selected`가 존재한다면, `selected` 요소를 없다면 첫번째 요소의 `tabIndex`가 0이 됩니다.
+   */
+  handleRovingFocus: (props: {
+    dom: React.RefObject<HTMLElement>;
+    selected?: string | string[];
+  }) => (e: React.FocusEvent) => void;
+};
+
+export const createRovingContext = () => {
+  const RovingContext = React.createContext<RovingContext | null>(null);
+
+  const RovingProvider = (props: { children: React.ReactNode }) => {
+    const { children } = props;
+    const rovingItems = React.useRef(new Map()).current;
+
+    const getItems = React.useCallback(() => {
+      return Array.from(rovingItems.values()).filter((item) => !item.disabled);
+    }, [rovingItems]);
+
+    const useRegister: RovingContext['useRegister'] = (id, props) => {
+      const { dom, value, disabled } = props;
+      React.useEffect(() => {
+        rovingItems.set(id, {
+          dom,
+          value,
+          disabled,
+        });
+
+        return () => {
+          rovingItems.delete(id);
+        };
+      }, [value, disabled, dom, id]);
+    };
+    // 내부적으로 React.useEffect를 담고 있는 커스텀훅이되어,
+    // useCallback으로 묶지 않았습니다.
+    // 다만, register에만 사용되므로 문제는 없었습니다.
+
+    const handleRovingKeyDown = React.useCallback(
+      (e: React.KeyboardEvent) => {
+        const { key } = e;
+        const items = getItems().map((item) => item.dom.current);
+        const currentFocusedIndex = getCurrentFocused(items);
+        const currentFocusedNode = items[currentFocusedIndex];
+        const [nextIndex, prevIndex] = getComputedIndex(currentFocusedIndex, items.length);
+
+        switch (true) {
+          case ROVING_KEYS.NEXT.includes(key): {
+            const nextNode = items[nextIndex];
+            setNodeUnFocusable(currentFocusedNode);
+            setNodeFocusable(nextNode);
+            setNodeFocus(nextNode);
+            break;
+          }
+
+          case ROVING_KEYS.PREV.includes(key): {
+            const prevNode = items[prevIndex];
+            setNodeUnFocusable(currentFocusedNode);
+            setNodeFocusable(prevNode);
+            setNodeFocus(prevNode);
+            break;
+          }
+          case ROVING_KEYS.HOME.includes(key): {
+            setNodeUnFocusable(currentFocusedNode);
+            setNodeFocusable(items[0]);
+            setNodeFocus(items[0]);
+            break;
+          }
+          case ROVING_KEYS.END.includes(key): {
+            setNodeUnFocusable(currentFocusedNode);
+            setNodeFocusable(items[items.length - 1]);
+            setNodeFocus(items[items.length - 1]);
+            break;
+          }
+          case ROVING_KEYS.CLOSE.includes(key): {
+            items.forEach(setNodeUnFocusable);
+            break;
+          }
+
+          default:
+            break;
+        }
+      },
+      [getItems]
+    );
+
+    const handleRovingFocus: RovingContext['handleRovingFocus'] = React.useCallback(
+      ({ dom, selected }) =>
+        (e: React.FocusEvent) => {
+          if (e.target !== dom.current) return;
+          const items = getItems();
+
+          const selectedIndex = Array.isArray(selected)
+            ? items.findIndex((item) => selected.includes(item.value))
+            : items.findIndex((item) => item.value === selected);
+
+          const computedIndex = selectedIndex === -1 ? 0 : selectedIndex;
+          const targetNode = items[computedIndex].dom.current;
+
+          items.forEach((item) => setNodeUnFocusable(item.dom.current));
+          setNodeFocusable(targetNode);
+          setNodeFocus(targetNode);
+        },
+      [getItems]
+    );
+
+    const value = React.useMemo(() => {
+      return { handleRovingKeyDown, useRegister, getItems, handleRovingFocus };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [handleRovingKeyDown, getItems, handleRovingFocus]);
+
+    return <RovingContext.Provider value={value}>{children}</RovingContext.Provider>;
+  };
+
+  const useRoving = () => {
+    const context = React.useContext(RovingContext);
+    if (!context) throw Error('useRovingContext should be used wrapped with RovingProvider');
+
+    return context;
+  };
+
+  RovingContext.displayName = 'RovingContext';
+  return { RovingProvider, useRoving };
+};

--- a/packages/createRovingContext/src/index.ts
+++ b/packages/createRovingContext/src/index.ts
@@ -1,0 +1,1 @@
+export * from './createRovingContext';

--- a/packages/createRovingContext/src/utils.ts
+++ b/packages/createRovingContext/src/utils.ts
@@ -16,7 +16,6 @@ const getComputedIndex = (curIndex: number, length: number) => {
 };
 const setNodeFocusable = (node: HTMLElement) => {
   node.tabIndex = TAB_INDEX.FOCUSABLE;
-  return node;
 };
 const setNodeUnFocusable = (node: HTMLElement) => {
   node.tabIndex = TAB_INDEX.UN_FOCUSABLE;

--- a/packages/createRovingContext/src/utils.ts
+++ b/packages/createRovingContext/src/utils.ts
@@ -1,0 +1,29 @@
+const TAB_INDEX = {
+  FOCUSABLE: 0,
+  UN_FOCUSABLE: -1,
+};
+
+const FIRST_INDEX = 0;
+
+const getCurrentFocused = (items: HTMLElement[]) => {
+  return items.findIndex((item) => item === document.activeElement);
+};
+const getComputedIndex = (curIndex: number, length: number) => {
+  return [
+    curIndex + 1 >= length ? FIRST_INDEX : curIndex + 1,
+    curIndex - 1 < 0 ? length - 1 : curIndex - 1,
+  ];
+};
+const setNodeFocusable = (node: HTMLElement) => {
+  node.tabIndex = TAB_INDEX.FOCUSABLE;
+  return node;
+};
+const setNodeUnFocusable = (node: HTMLElement) => {
+  node.tabIndex = TAB_INDEX.UN_FOCUSABLE;
+};
+
+const setNodeFocus = (node: HTMLElement) => {
+  node.focus();
+};
+
+export { getCurrentFocused, getComputedIndex, setNodeFocusable, setNodeUnFocusable, setNodeFocus };

--- a/packages/createRovingContext/tsconfig.json
+++ b/packages/createRovingContext/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/index.ts"],
+  "compilerOptions": {
+    "declarationDir": "./dist"
+  }
+}


### PR DESCRIPTION
closes #23 
# `over-ui/createRovingContext`

`createRovingContext` 패키지는, `over-ui` 패키기 내부에서 사용하는 훅입니다.
`radio, toggle` 컴포넌트를 작성할 때의 접근성 규칙을 준수하기 위해 `roving TabIndex`를 구현합니다.

## Usage

```tsx
// group 요소
const Container: Poly.Component<typeof DEFAULT_ROOT, ContainerProps> =
  React.forwardRef(
    <T extends React.ElementType = typeof DEFAULT_ROOT>(
      props: Poly.Props<T, ContainerProps>,
      ref: Poly.Ref<T>,
    ) => {
      ...
      const containerRef = React.useRef<HTMLDivElement>(null);
      const { handleRovingKeyDown, handleRovingFocus } = useRoving();

      // 그룹 요소에, rovingKeyDown, RovingFocus를 등록합니다.
      return (
        <Tag
          role='group'
          onFocus={composeEvent(
            handleRovingFocus({ dom: containerRef, selected: pressed }),
            theirOnFocus,
          )}
          onKeyDown={composeEvent(handleRovingKeyDown, theirOnKeyDown)}
          tabIndex={0}
          // 이 컴포넌트는 반드시, `focus` 될 수 있어야 합니다.
          // 접근성으로 인해 포커스가 되는 즉시 내부의 요소에 포커스가 이동합니다.
          ref={mergeRefs([containerRef, ref])}
          {...restProps}
        >
          {children}
        </Tag>
      );
    },
  );

// ---------

export const Item: Poly.Component<typeof DEFAULT_ITEM, ItemProps> =
  React.forwardRef(
    <T extends React.ElementType = typeof DEFAULT_ITEM>(
      props: Poly.Props<T, ItemProps>,
      ref: Poly.Ref<T>,
    ) => {
      const { children, value, disabled = false, ...restProps } = props;
      const ItemRef = React.useRef<HTMLButtonElement>(null);

      const { pressedValue, multiple, setValue, deleteValue } = useSafeContext(
        ToggleContext,
        ITEM_DISPLAY_NAME,
      );

      const { useRegister } = useRoving();

      useRegister(value, {
        dom: ItemRef,
        value,
        disabled,
      });
      ....
      // item 요소에서 register를 진행합니다.

```
